### PR TITLE
Add imports for alias + vector

### DIFF
--- a/app.zksound_scripts.move
+++ b/app.zksound_scripts.move
@@ -1,5 +1,6 @@
 module 0xc0ffee::zk_soundness_vault_scripts {
     use 0xc0ffee::zk_soundness_vault;
+    use std::vector;
 
     /// Initialize the vault once (admin must be the module / vault admin).
     ///


### PR DESCRIPTION
1. Give a shorter alias for the vault module.
2. Import std::vector so we can construct an empty commitment later.