### PR TITLE
Make get_note_metadata read-only (borrow_global instead of borrow_glo…

### DIFF
--- a/app.zksound.move
+++ b/app.zksound.move
@@ -23,13 +23,23 @@ module 0xc0ffee::zk_soundness_vault {
         note_id: u64,
         amount: u64,
     }
-/// Return minimal metadata for a given note ID:
+    /// Return minimal metadata for a given note ID:
     /// (owner, amount, spent)
     public fun get_note_metadata(note_id: u64): (address, u64, bool) acquires Vault {
-        let vault = borrow_global_mut<Vault>(ADMIN_ADDR);
-        let (_, note_ref) = find_note_mut(&mut vault.notes, note_id);
-        (note_ref.owner, note_ref.amount, note_ref.spent)
+        let vault = borrow_global<Vault>(ADMIN_ADDR);
+        let notes_ref = &vault.notes;
+        let len = vector::length<Note>(notes_ref);
+        let mut i = 0;
+        while (i < len) {
+            let note_ref = vector::borrow<Note>(notes_ref, i);
+            if (note_ref.id == note_id) {
+                return (note_ref.owner, note_ref.amount, note_ref.spent);
+            };
+            i = i + 1;
+        };
+        abort ENOTE_NOT_FOUND;
     }
+
     struct Note has copy, drop, store {
         id: u64,
         owner: address,


### PR DESCRIPTION
…bal_mut)

get_note_metadata only reads from the vault; it never mutates anything. Right now it uses borrow_global_mut<Vault>, which is unnecessary.