### PR TITLE
add get_vault_stats() helper (total_locked + note_count)

### DIFF
--- a/app.zksound.move
+++ b/app.zksound.move
@@ -161,6 +161,14 @@ module 0xc0ffee::zk_soundness_vault {
         let vault = borrow_global<Vault>(ADMIN_ADDR);
         vector::length<Note>(&vault.notes) as u64
     }
+    /// Return (total_locked, note_count) in a single call.
+    public fun get_vault_stats(): (u64, u64) acquires Vault {
+        let vault = borrow_global<Vault>(ADMIN_ADDR);
+        let total = vault.total_locked;
+        let count = vector::length<Note>(&vault.notes) as u64;
+        (total, count)
+    }
+
 
     fun find_note_mut(
         notes: &mut vector<Note>,


### PR DESCRIPTION
At the bottom comment mentions get_vault_stats, but it doesn’t exist. You already have get_total_locked() and get_note_count(). A tiny helper to return both is convenient for frontends / off-chain code.